### PR TITLE
Do not modify OPENSSL_ROOT_DIR in the CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,7 @@ if (NOT TARGET libzmq AND NOT TARGET libzmq-static)
     endif ()
 endif ()
 
-if (NOT DEFINED OPENSSL_LIBRARY)
-    set(OPENSSL_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
-    find_package(OpenSSL REQUIRED)
-endif ()
+find_package(OpenSSL REQUIRED)
 
 # Source files
 # ============


### PR DESCRIPTION
This is problematic because it prevents you from using a different (system) OpenSSL distribution.

Not exactly sure what the original intention was, but effectively this makes it so you can only use OpenSSL installed in the location you install xeus to (which doesn't make much sense). And besides you don't necessarily set `CMAKE_INSTALL_PREFIX` since you can override it with `cmake --install <dir> --prefix` at install-time. Perhaps the idea was:

```cmake
if (NOT DEFINED OPENSSL_ROOT_DIR)
    set(OPENSSL_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
endif()
```

But this is also wrong, you should use `-DCMAKE_PREFIX_PATH=<openssl prefix>` or `-DOPENSSL_ROOT_DIR=<openssl prefix>` on the CMake command line, not modify it in the project's CMake...