### PR TITLE
Adds copyToGlobals support information

### DIFF
--- a/include/xeus-zmq/xdebugger_base.hpp
+++ b/include/xeus-zmq/xdebugger_base.hpp
@@ -34,12 +34,15 @@ namespace xeus
         std::string m_tmp_file_suffix;
         bool m_rich_rendering;
         std::vector<std::string> m_exception_paths;
+        bool m_copy_to_globals;
 
         xdebugger_info(std::size_t hash_seed,
                        const std::string& tmp_file_prefix,
                        const std::string& tmp_file_suffix,
                        bool rich_rendering = false,
-                       std::vector<std::string> exception_paths = {});
+                       std::vector<std::string> exception_paths = {},
+                       bool copy_to_globals = false);
+
     };
 
     class XEUS_ZMQ_API xdebugger_base : public xdebugger
@@ -47,7 +50,7 @@ namespace xeus
     public:
 
         virtual ~xdebugger_base() = default;
-        
+
     protected:
 
         xdebugger_base(zmq::context_t& context);
@@ -105,7 +108,7 @@ namespace xeus
 
         zmq::socket_t m_header_socket;
         zmq::socket_t m_request_socket;
-        
+
         using request_handler_map_t = std::map<std::string, request_handler_t>;
         request_handler_map_t m_started_handler;
         request_handler_map_t m_request_handler;

--- a/src/xdebugger_base.cpp
+++ b/src/xdebugger_base.cpp
@@ -23,12 +23,14 @@ namespace xeus
                                    const std::string& tmp_file_prefix,
                                    const std::string& tmp_file_suffix,
                                    bool rich_rendering,
-                                   std::vector<std::string> exception_paths)
+                                   std::vector<std::string> exception_paths,
+                                   bool copy_to_globals)
         : m_hash_seed(hash_seed)
         , m_tmp_file_prefix(tmp_file_prefix)
         , m_tmp_file_suffix(tmp_file_suffix)
         , m_rich_rendering(rich_rendering)
         , m_exception_paths(exception_paths)
+        , m_copy_to_globals(copy_to_globals)
     {
     }
 
@@ -102,7 +104,8 @@ namespace xeus
                 {"breakpoints", breakpoint_list},
                 {"stoppedThreads", m_stopped_threads},
                 {"richRendering", info.m_rich_rendering},
-                {"exceptionPaths", info.m_exception_paths}
+                {"exceptionPaths", info.m_exception_paths},
+                {"copyToGlobals", info.m_copy_to_globals}
             }}
         };
         return reply;
@@ -257,7 +260,7 @@ namespace xeus
     {
         m_event_handler[event] = handler;
     }
-    
+
     void xdebugger_base::continued_event(const nl::json& message)
     {
         std::lock_guard<std::mutex> lock(m_stopped_mutex);
@@ -354,7 +357,7 @@ namespace xeus
                 }
                 else
                 {
-                    reply = 
+                    reply =
                     {
                         {"command", "initialize"},
                         {"request_seq", message["seq"]},


### PR DESCRIPTION
This PR adds information on `copyToGlobals` support in `debugger_info` response.

Should wait for https://github.com/jupyter/enhancement-proposals/pull/93