### PR TITLE
Update docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ copyright on their contributions.
 This software is licensed under the BSD-3-Clause license. See the LICENSE file
 for details.
 
-.. toctree:: 
+.. toctree::
    :caption: INSTALLATION
    :maxdepth: 2
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,16 +14,16 @@ With mamba or conda
 
 To ensure that the installation works, it is preferable to install ``xeus-zmq`` in a fresh environment.
 It is also needed to use a `miniforge`_  or `miniconda`_ installation because with the full `anaconda`_
-you may have a conflict with the ``zeroMQ`` library already installed in the distribution.
+you may have a conflict with the ``ZeroMQ`` library already installed in the distribution.
 
-The safest usage is to create an environment named ``xeus-zmq``
+The safest usage is to create an environment named ``xeus-env``
 
 .. code:: bash
 
-    mamba create -n xeus-zmq
-    mamba activate xeus-zmq
+    mamba create -n xeus-env
+    mamba activate xeus-env
 
-Then you can install in this freshly created environment ``xeus-zmq`` and its dependencies:
+Then you can install ``xeus-zmq`` and its dependencies in this freshly created environment:
 
 .. code:: bash
 
@@ -44,8 +44,8 @@ We have packaged all these dependencies on conda-forge. The simplest way to inst
 
 .. code:: bash
 
-    mamba env create -f environment-dev.yml -n xeus-zmq
-    mamba activate xeus-zmq
+    mamba env create -f environment-dev.yml -n xeus-env
+    mamba activate xeus-env
 
 You can then build and install ``xeus-zmq``:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -45,18 +45,18 @@ Instantiating a server
 
 `xeus-zmq` provides three different implementations for the server:
 
-- ``xserver_zmq_default`` is the default server implementaion, it runs three thread, one for publishing,
-  one for the heartbeat messages, and the main thread handles the shell, control and stdin sockets. To
+- ``xserver_zmq_default`` is the default server implementation; it runs three threads, one for publishing,
+  one for the heartbeat messages, and the main thread for handling the shell, control and stdin sockets. To
   instantiate this implementation, include ``xserver_zmq.hpp``  and call the ``make_xserver_default``
   function.
-- ``xserver_control_main`` runs an additional thread for handling the shell and the stdin sockets. Therefore
-  the main thread only listens to the control socket. This allow to easily implement interruption of code
+- ``xserver_control_main`` runs an additional thread for handling the shell and the stdin sockets. Therefore,
+  the main thread only listens to the control socket. This allows us to easily implement interruption of code
   execution. This server is required if you want to plug a debugger in the kernel. To instantiate this
-  implementation, include ``xserver_zmq_split`` and call the ``make_xserver_control_main`` function.
+  implementation, include ``xserver_zmq_split.hpp`` and call the ``make_xserver_control_main`` function.
 - ``xserver_shell_main`` is similar to ``xserver_control_main`` except that the main thread handles the shell
   and the stdin sockets while the additional thread listens to the control socket. This server is required if
   you want to plug a debugger that does not support native threads and requires the code to be run by the main
-  thread. To instantiate this implementation, include ``xserver_zmq_split``  and call the
+  thread. To instantiate this implementation, include ``xserver_zmq_split.hpp``  and call the
   ``make_xserver_shell_main`` function.
 
 Instantiating a client
@@ -67,10 +67,10 @@ have a look at our `ipc client class`_ and the `ipc client implementation file`_
 
 `xeus-zmq` currently provides a single implementation for the client:
 
-- ``xclient_zmq`` is the primary client implementaion, it runs two threads, one for sending a "ping" message to the
-  heartbeat each 100ms, one for polling the iopub socket and pushing the received message into a queue, and the main
-  thread waits for messages either popping messages from the queue or polling the shell and the controll sockets for
-  receieved messages. To instantiate this implementation, include ``xclient_zmq.hpp`` and call the
+- ``xclient_zmq`` is the primary client implementation, it runs two threads, one for sending a "ping" message to the
+  heartbeat every 100ms, and one for polling the iopub socket and pushing the received message into a queue. The main
+  thread waits for messages by either popping messages from the queue or polling the shell and the control sockets for
+  received messages. To instantiate this implementation, include ``xclient_zmq.hpp`` and call the
   ``make_xclient_zmq`` function.
 
 .. _ipc client class: https://github.com/jupyter-xeus/xeus-zmq/blob/main/test/xipc_client.hpp


### PR DESCRIPTION
- Fix typos
- Add example for extending runners
- Rename example environment to `xeus-env`. It seemed confusing to have the environment and the package both be named `xeus-zmq`