### PR TITLE
Update runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13]
         xeus_static_dependencies: [0]
         xeus_build_shared_lib: [1]
         include:
@@ -29,9 +29,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v2
 
       - name: Install micromamba
         uses: mamba-org/setup-micromamba@v1
@@ -57,7 +54,7 @@ jobs:
 
       - name: Build
         shell: bash -l {0}
-        run: make -j ${{ steps.cpu-cores.outputs.count }}
+        run: make -j ${{ runner.os == 'macOS' && 3 || 4 }}
         working-directory: build
 
       - name: Test xeus-zmq


### PR DESCRIPTION
> The macos-11 label has been deprecated and will no longer be available after 28/6/2024. 