### PR TITLE
Remove xtl reference from Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Versions prior to version 3 depend have an additional dependency on [xtl](https:
 We have packaged all these dependencies on conda-forge. The simplest way to install them is to run:
 
 ```bash
-mamba install cmake pkg-config zeromq cppzmq OpenSSL nlohmann_json=3.11.2 xtl xeus -c conda-forge
+mamba install cmake pkg-config zeromq cppzmq OpenSSL nlohmann_json=3.11.2 xeus -c conda-forge
 ```
 
 Once you have installed the dependencies, you can build and install `xeus-zmq`:
@@ -141,15 +141,6 @@ make install
 
 ```bash
 cmake
-make install
-```
-
-### xtl
-
-[xtl](https://github.com/xtensor-stack/xtl) is a header only library:
-
-```bash
-cmake -D CMAKE_BUILD_TYPE
 make install
 ```
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,7 +36,6 @@ From source
  - libzmq_
  - cppzmq_
  - OpenSSL_
- - xtl_
  - nlohmann_json_
  - xeus_
 
@@ -63,5 +62,4 @@ You can then build and install ``xeus-zmq``:
 .. _cppzmq: https://github.com/zeromq/cppzmq
 .. _OpenSSL: https://github.com/OpenSSL/OpenSSL
 .. _nlohmann_json: https://github.com/nlohmann/json
-.. _xtl: https://github.com/xtensor-stack/xtl
 .. _xeus: https://github.com/jupyter-xeus/xeus


### PR DESCRIPTION
I guess we can get rid of these xtl references from docs as xeus-zmq no longer depends on it !