### PR TITLE
Fixed potentially invalid access in json message

### DIFF
--- a/src/debugger/xdap_tcp_client_impl.cpp
+++ b/src/debugger/xdap_tcp_client_impl.cpp
@@ -57,7 +57,7 @@ namespace xeus
             send_dap_request(std::move(req));
             auto rep = wait_for_message([](const nl::json& msg)
             {
-                return msg["command"] == "threads";
+                return msg.contains("command") && msg["command"] == "threads";
             });
             nl::json new_message = message;
             new_message["body"]["threadList"] = nl::json::array();


### PR DESCRIPTION
Accessing a missing key in a constant json through operator[] is actually undefined behavior and triggers an assert in debug.